### PR TITLE
PLAT-698: fix installation compatibility

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+//  Copyright 2020 Insolar Network Ltd.
+//  All rights reserved.
+//  This material is licensed under the Insolar License version 1.0,
+//  available at https://github.com/insolar/testrail-cli/LICENSE.md.
+
+// stub top-level package to save installation compatibility for
+// old and new versions of testrail-cli
+package testrailcli
+


### PR DESCRIPTION
added stub for installation compatibility between old and new versions of testrail-cli